### PR TITLE
aiohttp >= 0.21 and Python 3.5.1 comaptibilty

### DIFF
--- a/webtest_aiohttp.py
+++ b/webtest_aiohttp.py
@@ -56,6 +56,7 @@ def WSGIHandler(app):
             app, app.router, loop=loop, keep_alive_on=False)
         handler = factory()
         handler.transport = io.BytesIO()
+        handler.transport.is_closing = lambda: False
         handler.transport._conn_lost = 0
         handler.transport.get_extra_info = lambda s: ('127.0.0.1', 80)
         handler.writer = aiohttp.parsers.StreamWriter(

--- a/webtest_aiohttp.py
+++ b/webtest_aiohttp.py
@@ -48,7 +48,7 @@ def WSGIHandler(app):
         req = webob.Request(environ)
         vers = aiohttp.HttpVersion10 if req.http_version == 'HTTP/1.0' else aiohttp.HttpVersion11
         message = aiohttp.RawRequestMessage(
-            req.method, req.path_qs, vers, aiohttp.CIMultiDict(req.headers), False, False)
+            req.method, req.path_qs, vers, aiohttp.CIMultiDict(req.headers), False, False, False)
         payload = aiohttp.StreamReader(loop=loop)
         payload.feed_data(req.body)
         payload.feed_eof()
@@ -58,7 +58,9 @@ def WSGIHandler(app):
         handler.transport = io.BytesIO()
         handler.transport.is_closing = lambda: False
         handler.transport._conn_lost = 0
-        handler.transport.get_extra_info = lambda s: ('127.0.0.1', 80)
+        handler.transport.get_extra_info = lambda s: {
+            'peername': ('127.0.0.1', 80)
+        }.get(s)
         handler.writer = aiohttp.parsers.StreamWriter(
             handler.transport, handler, handler.reader, handler._loop)
         coro = handler.handle_request(message, payload)


### PR DESCRIPTION
Fixes issues with:

https://github.com/KeepSafe/aiohttp/issues/760
https://docs.python.org/3/library/asyncio-protocol.html#asyncio.BaseTransport.is_closing

Also, modfied `get_extra_info` so that it does not crash on `get_extra_info('socket').family` call by returning `None` instead of tuple. It makes tests pass, though it's still a hack.
